### PR TITLE
fix(security): #3 remove hardcoded data.go.kr serviceKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ vite.config.*.timestamp*
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 apps/web/.next
+
+# env
+.env
+.env.local
+.env.*.local
+

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,8 @@
+# Korean public-data-portal service key for the abandonmentPublicSrvc API.
+# Get one at https://www.data.go.kr/ and copy this file to apps/web/.env.local
+# (which is git-ignored).
+#
+# NEXT_PUBLIC_ prefix = exposed to the browser. A server-side proxy via a
+# Next Route Handler is tracked under #9 (Vercel deploy); that will let us
+# drop the NEXT_PUBLIC_ prefix and keep the key server-only.
+NEXT_PUBLIC_DATA_GO_KR_SERVICE_KEY=

--- a/apps/web/src/new-api/service.ts
+++ b/apps/web/src/new-api/service.ts
@@ -1,21 +1,34 @@
-import axios from "axios";
-import { APIResponse } from "@animal-project/shared-types";
+import axios from 'axios';
+import { APIResponse } from '@animal-project/shared-types';
 
-const baseURL = 'http://apis.data.go.kr/1543061/abandonmentPublicSrvc'
-const serviceKey = 'GsGMbaDETPd05r326o0ICejVO+U/XwTQES1Tf8Vl3wL0fuYEMxV/3Ai2pLmcPFT9yWXTlE9DwTf7H1dR3ezWgg=='
+const baseURL = 'http://apis.data.go.kr/1543061/abandonmentPublicSrvc';
+
+// NEXT_PUBLIC_ because getAPI runs in the browser (TanStack Query
+// client). The key is still visible in the Network tab; moving getAPI
+// behind a Next Route Handler (apps/web/app/api/**) removes even that
+// exposure and is tracked under #9 (Vercel deploy). This change only
+// removes the literal key from git history so it can be rotated.
+const serviceKey = process.env.NEXT_PUBLIC_DATA_GO_KR_SERVICE_KEY;
+
+if (!serviceKey) {
+  // eslint-disable-next-line no-console
+  console.error(
+    'NEXT_PUBLIC_DATA_GO_KR_SERVICE_KEY is not set. See apps/web/.env.example.'
+  );
+}
 
 export const serviceAPI = axios.create({
-    baseURL : baseURL,
-    timeout : 10000,
-})
+  baseURL,
+  timeout: 10000,
+});
 
-export const getAPI = async <T, K>(props : T, path : string) => {
-    const data = await serviceAPI.get<APIResponse<K>>(path, {
-        params : {
-            ...props,
-            serviceKey : serviceKey,
-            _type: 'json'
-        }
-    })
-    return data.data;
-}
+export const getAPI = async <T, K>(props: T, path: string) => {
+  const data = await serviceAPI.get<APIResponse<K>>(path, {
+    params: {
+      ...props,
+      serviceKey,
+      _type: 'json',
+    },
+  });
+  return data.data;
+};


### PR DESCRIPTION
## Summary
Moves the Korean public-data-portal key out of `apps/web/src/new-api/service.ts` and behind `process.env.NEXT_PUBLIC_DATA_GO_KR_SERVICE_KEY`. Adds `apps/web/.env.example` and extends root `.gitignore` with `.env*` patterns.

The `NEXT_PUBLIC_` prefix is a deliberate tradeoff: `getAPI` still runs in the browser via TanStack Query, so the key remains visible in the Network tab. The proper fix (Next Route Handler proxy keeping the key server-only) belongs under **#9 (Vercel deploy)** and is referenced in both the env example and the inline comment in `service.ts`.

Closes #3 (literal removal). Does **not** close the rotation half — see action required below.

## 🚨 Required manual actions after merge

1. **Rotate the key** at https://www.data.go.kr/. The previous value remains in git history on all pre-merge commits and must be considered compromised.
2. Create `apps/web/.env.local` with the new value for local dev.
3. Add `NEXT_PUBLIC_DATA_GO_KR_SERVICE_KEY` to the Vercel project env (scope: Preview, Production) — part of #9.

## Test plan
- [x] `grep -rn "GsGMbaDE" apps/web/src` → no matches (literal removed)
- [x] `npx nx affected -t lint test build --exclude web-e2e` green
- [x] Runtime: with the env var unset, `service.ts` logs a loud `console.error`; with it set, requests go out with the correct `serviceKey` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Externalize the Korean public data API key from the web app source into an environment variable and add supporting configuration for local and deployed environments.

Enhancements:
- Replace the hardcoded data.go.kr service key in the web API client with a NEXT_PUBLIC_ environment variable and add a runtime warning when it is missing.

Build:
- Extend the root .gitignore to exclude .env* files from version control.

Documentation:
- Add an apps/web/.env.example file documenting the required NEXT_PUBLIC_DATA_GO_KR_SERVICE_KEY environment variable.