### PR TITLE
chore(deploy): #62 remove Vite-era root vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/index.html"
-    }
-  ]
-}


### PR DESCRIPTION
## Summary
Root `vercel.json` was a Vite SPA rewrite (`/(.*) → /index.html`) that would break Next.js deploys by routing every path into a nonexistent `index.html`. The Next App Router handles routing itself — no Vercel-layer rewrite needed.

Per the Vercel monorepo guide + roadmap, `web` and `api` will each become their own Vercel project with `Root Directory` set to `apps/web` and `apps/api` respectively. A root-level `vercel.json` would apply to both and can't express per-app config coherently, so it stays removed.

Closes #62. Unblocks #63/#64/#65.

## Test plan
- [x] `npx nx affected -t lint test build --exclude web-e2e` green (10/10 remote cache hits)
- [x] No `vercel.json` left at repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Delete legacy Vite-era vercel.json from the repository root so deployment configuration can be managed per app.