### PR TITLE
chore(deps): #64 drop unused @vercel/remote-nx

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,8 +1,8 @@
 # Korean public-data-portal service key for the abandonmentPublicSrvc API.
 # Get one at https://www.data.go.kr/ and copy this file to apps/web/.env.local
-# (which is git-ignored).
+# (git-ignored).
 #
-# NEXT_PUBLIC_ prefix = exposed to the browser. A server-side proxy via a
-# Next Route Handler is tracked under #9 (Vercel deploy); that will let us
-# drop the NEXT_PUBLIC_ prefix and keep the key server-only.
-NEXT_PUBLIC_DATA_GO_KR_SERVICE_KEY=
+# Server-only — no NEXT_PUBLIC_ prefix. Read by the Next Route Handler
+# at apps/web/app/api/data-go-kr/[...path]/route.ts; never shipped to
+# the browser bundle.
+DATA_GO_KR_SERVICE_KEY=

--- a/apps/web/app/api/data-go-kr/[...path]/route.ts
+++ b/apps/web/app/api/data-go-kr/[...path]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 const UPSTREAM_BASE =
-  'http://apis.data.go.kr/1543061/abandonmentPublicSrvc';
+  'https://apis.data.go.kr/1543061/abandonmentPublicService_v2';
 
 export async function GET(
   request: NextRequest,

--- a/apps/web/app/api/data-go-kr/[...path]/route.ts
+++ b/apps/web/app/api/data-go-kr/[...path]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const UPSTREAM_BASE =
+  'http://apis.data.go.kr/1543061/abandonmentPublicSrvc';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  const serviceKey = process.env.DATA_GO_KR_SERVICE_KEY;
+  if (!serviceKey) {
+    return NextResponse.json(
+      { error: 'DATA_GO_KR_SERVICE_KEY is not configured on the server.' },
+      { status: 500 }
+    );
+  }
+
+  const { path } = await context.params;
+  const upstreamPath = path.join('/');
+
+  const params = new URLSearchParams(request.nextUrl.searchParams);
+  params.set('serviceKey', serviceKey);
+  params.set('_type', 'json');
+
+  const upstreamUrl = `${UPSTREAM_BASE}/${upstreamPath}?${params.toString()}`;
+
+  try {
+    const upstream = await fetch(upstreamUrl, {
+      headers: { Accept: 'application/json' },
+    });
+    const body = await upstream.text();
+    return new NextResponse(body, {
+      status: upstream.status,
+      headers: {
+        'content-type':
+          upstream.headers.get('content-type') ?? 'application/json',
+      },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'Upstream fetch failed', message: String(err) },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/web/src/new-api/animalInfo/index.ts
+++ b/apps/web/src/new-api/animalInfo/index.ts
@@ -2,4 +2,4 @@ import { AnimalInfoRequestType } from "@animal-project/shared-types";
 import { getAPI } from "../service";
 import { AnimalInfo } from "@animal-project/shared-types";
 
-export const getAnimalInfo = (props : AnimalInfoRequestType) => getAPI<AnimalInfoRequestType, AnimalInfo>(props, '/abandonmentPublic')
+export const getAnimalInfo = (props : AnimalInfoRequestType) => getAPI<AnimalInfoRequestType, AnimalInfo>(props, '/abandonmentPublic_v2')

--- a/apps/web/src/new-api/kind/index.ts
+++ b/apps/web/src/new-api/kind/index.ts
@@ -2,4 +2,4 @@ import { KindRequestType } from "@animal-project/shared-types";
 import { getAPI } from "../service";
 import { Kind } from "@animal-project/shared-types";
 
-export const getKind = (props : KindRequestType) => getAPI<KindRequestType, Kind>(props, '/kind')
+export const getKind = (props : KindRequestType) => getAPI<KindRequestType, Kind>(props, '/kind_v2')

--- a/apps/web/src/new-api/service.ts
+++ b/apps/web/src/new-api/service.ts
@@ -1,21 +1,10 @@
 import axios from 'axios';
 import { APIResponse } from '@animal-project/shared-types';
 
-const baseURL = 'http://apis.data.go.kr/1543061/abandonmentPublicSrvc';
-
-// NEXT_PUBLIC_ because getAPI runs in the browser (TanStack Query
-// client). The key is still visible in the Network tab; moving getAPI
-// behind a Next Route Handler (apps/web/app/api/**) removes even that
-// exposure and is tracked under #9 (Vercel deploy). This change only
-// removes the literal key from git history so it can be rotated.
-const serviceKey = process.env.NEXT_PUBLIC_DATA_GO_KR_SERVICE_KEY;
-
-if (!serviceKey) {
-  // eslint-disable-next-line no-console
-  console.error(
-    'NEXT_PUBLIC_DATA_GO_KR_SERVICE_KEY is not set. See apps/web/.env.example.'
-  );
-}
+// Calls go to the Next Route Handler at app/api/data-go-kr/[...path],
+// which proxies to the public-data-portal and injects the server-only
+// DATA_GO_KR_SERVICE_KEY. The browser never sees the key.
+const baseURL = '/api/data-go-kr';
 
 export const serviceAPI = axios.create({
   baseURL,
@@ -26,8 +15,6 @@ export const getAPI = async <T, K>(props: T, path: string) => {
   const data = await serviceAPI.get<APIResponse<K>>(path, {
     params: {
       ...props,
-      serviceKey,
-      _type: 'json',
     },
   });
   return data.data;

--- a/apps/web/src/new-api/shelter/index.ts
+++ b/apps/web/src/new-api/shelter/index.ts
@@ -2,4 +2,4 @@ import { ShelterRequestType } from "@animal-project/shared-types";
 import { getAPI } from "../service";
 import { Shelter } from "@animal-project/shared-types";
 
-export const getShelter = (props : ShelterRequestType) => getAPI<ShelterRequestType, Shelter>(props, '/shelter')
+export const getShelter = (props : ShelterRequestType) => getAPI<ShelterRequestType, Shelter>(props, '/shelter_v2')

--- a/apps/web/src/new-api/sido/index.ts
+++ b/apps/web/src/new-api/sido/index.ts
@@ -2,5 +2,5 @@ import { SidoRequestType } from "@animal-project/shared-types";
 import { getAPI } from "../service";
 import { Sido } from "@animal-project/shared-types";
 
-export const getSido = (props : SidoRequestType) => getAPI<SidoRequestType, Sido>(props, '/sido')
+export const getSido = (props : SidoRequestType) => getAPI<SidoRequestType, Sido>(props, '/sido_v2')
 

--- a/apps/web/src/new-api/sigungu/index.ts
+++ b/apps/web/src/new-api/sigungu/index.ts
@@ -2,4 +2,4 @@ import { SigunguRequestType } from "@animal-project/shared-types";
 import { getAPI } from "../service";
 import { Sigungu } from "@animal-project/shared-types";
 
-export const getSigungu = (props : SigunguRequestType) => getAPI<SigunguRequestType, Sigungu>(props, '/sigungu')
+export const getSigungu = (props : SigunguRequestType) => getAPI<SigunguRequestType, Sigungu>(props, '/sigungu_v2')

--- a/apps/web/src/new-site/search/card/AnimalCard.tsx
+++ b/apps/web/src/new-site/search/card/AnimalCard.tsx
@@ -23,7 +23,7 @@ export const AnimalCard = (props: Props) => {
         </motion.div>
       </div>
       <figure className="px-10 pt-10">
-        <img src={item.popfile} alt="pet" className="rounded-xl h-32" />
+        <img src={item.popfile1} alt="pet" className="rounded-xl h-32" />
       </figure>
       <CardContent className="flex flex-col items-center text-center">
         <table className="text-sm">

--- a/libs/shared-types/src/lib/responseAPI.ts
+++ b/libs/shared-types/src/lib/responseAPI.ts
@@ -55,7 +55,14 @@ export interface APIResponse<T> {
     noticeNo: string; // 공고번호
     noticeSdt: string; // 공고시작일 (YYYYMMDD)
     noticeEdt: string; // 공고종료일 (YYYYMMDD)
-    popfile: string; // Image URL
+    popfile1: string; // Image URL (v2 API: up to 8 images popfile1..popfile8)
+    popfile2?: string;
+    popfile3?: string;
+    popfile4?: string;
+    popfile5?: string;
+    popfile6?: string;
+    popfile7?: string;
+    popfile8?: string;
     processState: string; // 상태 (예: 보호중)
     sexCd: string; // 성별 (M: 수컷, F: 암컷, Q: 미상)
     neuterYn: string; // 중성화 여부 (Y: 예, N: 아니오, U: 미상)

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^7.16.0",
         "@typescript-eslint/parser": "^7.16.0",
-        "@vercel/remote-nx": "^2.0.0",
         "autoprefixer": "10.4.13",
         "babel-jest": "30.0.5",
         "eslint": "~8.57.0",
@@ -13359,398 +13358,6 @@
         "win32"
       ]
     },
-    "node_modules/@vercel/remote": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/remote/-/remote-1.0.1.tgz",
-      "integrity": "sha512-5iUXUO/DBsNPFPq1tuIndhq+x14Nec1lyj0F2IelWm/cVFl7q8dnXsAPtMnr1129RD8hbOTqI2XgXKo8orAlpA==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "ci-info": "^3.4.0",
-        "concat-stream": "^2.0.0",
-        "node-fetch": "^2.6.7",
-        "raw-body": "^2.5.1"
-      }
-    },
-    "node_modules/@vercel/remote-nx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/remote-nx/-/remote-nx-2.0.0.tgz",
-      "integrity": "sha512-lO5zIXnfg6Igi3Zpsf6uzSPXassO7j4udA5Jn++qKyUTqtzpn0rUav5VmNxDTS4nEDJhrYyRJwx7oUNp7yQyTQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@vercel/remote": "1.0.1",
-        "chalk": "^4.1.0",
-        "nx-remotecache-custom": "^17.1.1"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nrwl/tao": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-17.3.2.tgz",
-      "integrity": "sha512-5uvpSmij0J9tteFV/0M/024K+H/o3XAlqtSdU8j03Auj1IleclSLF2yCTuIo7pYXhG3cgx1+nR+3nMs1QVAdUA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "nx": "17.3.2",
-        "tslib": "^2.3.0"
-      },
-      "bin": {
-        "tao": "index.js"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nx/nx-darwin-arm64": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-17.3.2.tgz",
-      "integrity": "sha512-hn12o/tt26Pf4wG+8rIBgNIEZq5BFlHLv3scNrgKbd5SancHlTbY4RveRGct737UQ/78GCMCgMDRgNdagbCr6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nx/nx-darwin-x64": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-17.3.2.tgz",
-      "integrity": "sha512-5F28wrfE7yU60MzEXGjndy1sPJmNMIaV2W/g82kTXzxAbGHgSjwrGFmrJsrexzLp9oDlWkbc6YmInKV8gmmIaQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nx/nx-freebsd-x64": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-17.3.2.tgz",
-      "integrity": "sha512-07MMTfsJooONqL1Vrm5L6qk/gzmSrYLazjkiTmJz+9mrAM61RdfSYfO3mSyAoyfgWuQ5yEvfI56P036mK8aoPg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-17.3.2.tgz",
-      "integrity": "sha512-gQxMF6U/h18Rz+FZu50DZCtfOdk27hHghNh3d3YTeVsrJTd1SmUQbYublmwU/ia1HhFS8RVI8GvkaKt5ph0HoA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-17.3.2.tgz",
-      "integrity": "sha512-X20wiXtXmKlC01bpVEREsRls1uVOM22xDTpqILvVty6+P+ytEYFR3Vs5EjDtzBKF51wjrwf03rEoToZbmgM8MA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-17.3.2.tgz",
-      "integrity": "sha512-yko3Xsezkn4tjeudZYLjxFl07X/YB84K+DLK7EFyh9elRWV/8VjFcQmBAKUS2r9LfaEMNXq8/vhWMOWYyWBrIA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-17.3.2.tgz",
-      "integrity": "sha512-RiPvvQMmlZmDu9HdT6n6sV0+fEkyAqR5VocrD5ZAzEzFIlh4dyVLripFR3+MD+QhIhXyPt/hpri1kq9sgs4wnw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-17.3.2.tgz",
-      "integrity": "sha512-PWfVGmFsFJi+N1Nljg/jTKLHdufpGuHlxyfHqhDso/o4Qc0exZKSeZ1C63WkD7eTcT5kInifTQ/PffLiIDE3MA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-17.3.2.tgz",
-      "integrity": "sha512-O+4FFPbQz1mqaIj+SVE02ppe7T9ELj7Z5soQct5TbRRhwjGaw5n5xaPPBW7jUuQe2L5htid1E82LJyq3JpVc8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-17.3.2.tgz",
-      "integrity": "sha512-4hQm+7coy+hBqGY9J709hz/tUPijhf/WS7eML2r2xBmqBew3PMHfeZuaAAYWN690nIsu0WX3wyDsNjulR8HGPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/@zkochan/js-yaml": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
-      "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/dotenv": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.2.tgz",
-      "integrity": "sha512-HTlk5nmhkm8F6JcdXvHIzaorzCoziNQT9mGxLPVXW8wJF1TiGSL60ZGB4gHWabHOaMmWmhvk2/lPHfnBiT78AQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/dotenv-expand": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
-      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/nx": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-17.3.2.tgz",
-      "integrity": "sha512-QjF1gnwKebQISvATrSbW7dsmIcLbA0fcyDyxLo5wVHx/MIlcaIb/lLYaPTld73ZZ6svHEZ6n2gOkhMitmkIPQA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@nrwl/tao": "17.3.2",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.0-rc.46",
-        "@zkochan/js-yaml": "0.0.6",
-        "axios": "^1.6.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "3.1.0",
-        "cli-spinners": "2.6.1",
-        "cliui": "^8.0.1",
-        "dotenv": "~16.3.1",
-        "dotenv-expand": "~10.0.0",
-        "enquirer": "~2.3.6",
-        "figures": "3.2.0",
-        "flat": "^5.0.2",
-        "fs-extra": "^11.1.0",
-        "ignore": "^5.0.4",
-        "jest-diff": "^29.4.1",
-        "js-yaml": "4.1.0",
-        "jsonc-parser": "3.2.0",
-        "lines-and-columns": "~2.0.3",
-        "minimatch": "9.0.3",
-        "node-machine-id": "1.1.12",
-        "npm-run-path": "^4.0.1",
-        "open": "^8.4.0",
-        "ora": "5.3.0",
-        "semver": "^7.5.3",
-        "string-width": "^4.2.3",
-        "strong-log-transformer": "^2.1.0",
-        "tar-stream": "~2.2.0",
-        "tmp": "~0.2.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0",
-        "yargs": "^17.6.2",
-        "yargs-parser": "21.1.1"
-      },
-      "bin": {
-        "nx": "bin/nx.js",
-        "nx-cloud": "bin/nx-cloud.js"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "17.3.2",
-        "@nx/nx-darwin-x64": "17.3.2",
-        "@nx/nx-freebsd-x64": "17.3.2",
-        "@nx/nx-linux-arm-gnueabihf": "17.3.2",
-        "@nx/nx-linux-arm64-gnu": "17.3.2",
-        "@nx/nx-linux-arm64-musl": "17.3.2",
-        "@nx/nx-linux-x64-gnu": "17.3.2",
-        "@nx/nx-linux-x64-musl": "17.3.2",
-        "@nx/nx-win32-arm64-msvc": "17.3.2",
-        "@nx/nx-win32-x64-msvc": "17.3.2"
-      },
-      "peerDependencies": {
-        "@swc-node/register": "^1.6.7",
-        "@swc/core": "^1.3.85"
-      },
-      "peerDependenciesMeta": {
-        "@swc-node/register": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vercel/remote-nx/node_modules/nx-remotecache-custom": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/nx-remotecache-custom/-/nx-remotecache-custom-17.1.1.tgz",
-      "integrity": "sha512-p9ccy0piga2rAb22ULV1ZyRaC6No2hIh3UIN2uQJ7WP1kM+NF7Gk3K2hQo4urnYxSF6QzQI71KcKS5DVLsqOLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "dotenv": "^16.0.3",
-        "tar": "^6.1.12"
-      },
-      "peerDependencies": {
-        "nx": "^17.0.0"
-      }
-    },
-    "node_modules/@vercel/remote/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vercel/remote/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vercel/remote/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@vercel/remote/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/@vitest/expect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.0.tgz",
@@ -14294,47 +13901,6 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/@yarnpkg/parsers": {
-      "version": "3.0.0-rc.46",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.46.tgz",
-      "integrity": "sha512-aiATs7pSutzda/rq8fnuPwTglyVwjM22bNnK2ZgjrpAjQHSSl3lztd2f9evst1W/qnC58DRz7T7QndUDumAR4Q==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "js-yaml": "^3.10.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      }
-    },
-    "node_modules/@yarnpkg/parsers/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/@zkochan/js-yaml": {
       "version": "0.0.7",
@@ -16084,16 +15650,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -17609,6 +17165,7 @@
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -17794,14 +17351,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -19960,55 +19509,6 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fs-monkey": {
       "version": "1.1.0",
@@ -23576,23 +23076,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-docblock": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
@@ -24180,17 +23663,6 @@
         "graceful-fs": "^4.2.9",
         "picomatch": "^2.2.3"
       },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-get-type": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -26440,17 +25912,6 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/little-state-machine": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/little-state-machine/-/little-state-machine-4.8.0.tgz",
@@ -27030,40 +26491,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/mlly": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.1.tgz",
@@ -27356,14 +26783,6 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-machine-id": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
-      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
@@ -29664,72 +29083,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/raw-body/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -31994,25 +31347,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/strong-log-transformer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
-      "integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "duplexer": "^0.1.1",
-        "minimist": "^1.2.0",
-        "through": "^2.3.4"
-      },
-      "bin": {
-        "sl-log-transformer": "bin/sl-log-transformer.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strtok3": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
@@ -32482,24 +31816,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -32516,36 +31832,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tar/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/tcp-port-used": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
-    "@vercel/remote-nx": "^2.0.0",
     "autoprefixer": "10.4.13",
     "babel-jest": "30.0.5",
     "eslint": "~8.57.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/index.html"
-    }
-  ]
-}


### PR DESCRIPTION
## Summary
Stacked on #69. `@vercel/remote-nx` wires Nx Remote Cache into a Vercel-hosted endpoint via `tasksRunnerOptions` in `nx.json`. This repo has never had any `tasksRunnerOptions` wired to it (we use the standard Nx Cloud runner via `nxCloudAccessToken`), so the dep is dead weight.

Closes #64.

## Test plan
- [x] `grep '@vercel/remote-nx' apps libs` → zero source references
- [x] `npx nx affected -t lint test build --exclude web-e2e` green (10/10 cache hits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route public-data-portal traffic through a Next.js API proxy using a server-only key, migrate clients to the v2 abandonment API, and drop unused Vercel/Nx integration config and dependency.

New Features:
- Add a Next.js route handler that proxies data.go.kr abandonment API requests and injects the server-side DATA_GO_KR_SERVICE_KEY.

Bug Fixes:
- Ensure the public-data-portal API key is no longer exposed to the browser by moving key injection to a server-side proxy.

Enhancements:
- Update web client requests and shared response types to use the v2 abandonment API paths and support multiple image fields.
- Adjust the animal search card to consume the new primary image field from the v2 API.

Build:
- Remove the unused @vercel/remote-nx dependency from the project.

Deployment:
- Delete legacy Vercel configuration that is no longer needed with the new Next.js route handler proxy.