### PR TITLE
test(web): starter unit tests for service, header, bottom

### DIFF
--- a/apps/web/src/api/service.spec.ts
+++ b/apps/web/src/api/service.spec.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+jest.mock('axios');
+
+const axios = require('axios');
+const mockGet = jest.fn();
+(axios.create as jest.Mock).mockReturnValue({ get: mockGet });
+
+// Require service.ts AFTER axios.create is wired so the module-scope
+// `serviceAPI = axios.create(...)` captures the mocked instance.
+const { getAPI } = require('./service');
+
+describe('getAPI', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('creates the axios instance pointed at the Next route handler proxy', () => {
+    expect(axios.create).toHaveBeenCalledWith({
+      baseURL: '/api/data-go-kr',
+      timeout: 10000,
+    });
+  });
+
+  it('forwards the path and merges props as query params', async () => {
+    mockGet.mockResolvedValue({ data: { foo: 'bar' } });
+
+    const result = await getAPI({ pageNo: 1, numOfRows: 10 }, '/sido_v2');
+
+    expect(mockGet).toHaveBeenCalledWith('/sido_v2', {
+      params: { pageNo: 1, numOfRows: 10 },
+    });
+    expect(result).toEqual({ foo: 'bar' });
+  });
+
+  it('returns the unwrapped response data', async () => {
+    mockGet.mockResolvedValue({ data: { count: 42 } });
+    const result = await getAPI({}, '/kind_v2');
+    expect(result).toEqual({ count: 42 });
+  });
+});

--- a/apps/web/src/components/bottom.spec.tsx
+++ b/apps/web/src/components/bottom.spec.tsx
@@ -8,6 +8,7 @@ jest.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
 }));
 
+// eslint-disable-next-line import/first
 import { Bottom } from './bottom';
 
 describe('Bottom', () => {

--- a/apps/web/src/components/bottom.spec.tsx
+++ b/apps/web/src/components/bottom.spec.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const mockPush = jest.fn();
+let mockPathname = '/';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathname,
+}));
+
+import { Bottom } from './bottom';
+
+describe('Bottom', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockPathname = '/';
+  });
+
+  it('renders three nav items with aria labels', () => {
+    render(<Bottom />);
+    expect(screen.getByLabelText('홈')).toBeTruthy();
+    expect(screen.getByLabelText('조회하기')).toBeTruthy();
+    expect(screen.getByLabelText('좋아요')).toBeTruthy();
+  });
+
+  it('calls router.push with the item path on click', () => {
+    render(<Bottom />);
+    fireEvent.click(screen.getByLabelText('조회하기'));
+    expect(mockPush).toHaveBeenCalledWith('/search');
+  });
+
+  it('marks the matching pathname item as active', () => {
+    mockPathname = '/like';
+    render(<Bottom />);
+    expect(screen.getByLabelText('좋아요').className).toMatch(/text-primary/);
+    expect(screen.getByLabelText('홈').className).not.toMatch(/text-primary/);
+  });
+});

--- a/apps/web/src/components/header.spec.tsx
+++ b/apps/web/src/components/header.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('front/hooks', () => ({
+  useSido: () => ({ data: [] }),
+}));
+
+jest.mock('front/site/home/Count', () => ({
+  CountList: () => null,
+}));
+
+import Header from './header';
+
+describe('Header', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it('renders the title link', () => {
+    render(<Header />);
+    expect(screen.getByText('유기동물 조회 서비스')).toBeTruthy();
+  });
+
+  it('navigates to / when the title is clicked', () => {
+    render(<Header />);
+    fireEvent.click(screen.getByText('유기동물 조회 서비스'));
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+});

--- a/apps/web/src/components/header.spec.tsx
+++ b/apps/web/src/components/header.spec.tsx
@@ -13,6 +13,7 @@ jest.mock('front/site/home/Count', () => ({
   CountList: () => null,
 }));
 
+// eslint-disable-next-line import/first
 import Header from './header';
 
 describe('Header', () => {


### PR DESCRIPTION
## Summary
Three small specs covering the most reachable surfaces. The placeholder `app/providers.spec.tsx` from #30 stays.

### `src/api/service.spec.ts`
Mocks axios at the module boundary (`require` pattern instead of ES import so `axios.create` is stubbed before `service.ts` evaluates). Asserts:
- the axios instance is created with `baseURL: '/api/data-go-kr'`
- `getAPI` forwards path + props as query params
- it unwraps the response data envelope

### `src/components/header.spec.tsx`
Mocks `next/navigation`, `front/hooks` (`useSido`), and `front/site/home/Count` (`CountList`) so `Header` can render in isolation. Asserts:
- the title link renders
- clicking it calls `router.push('/')`

### `src/components/bottom.spec.tsx`
Mocks `next/navigation` (`useRouter` + `usePathname`). Asserts:
- three nav items render with their aria labels
- clicking '조회하기' fires `router.push('/search')`
- the active item picks up the `text-primary` class when `usePathname` matches

## Test plan
- [x] `npx nx test web`: 4 suites, 9 tests, all pass
- [x] `npx nx affected -t lint test build` green (5 projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add initial unit test coverage for the web app service API wrapper and key navigation components.

Tests:
- Add tests for the service API helper to validate axios configuration, query param handling, and response unwrapping.
- Add isolated unit tests for the header component to verify title rendering and navigation via router.push.
- Add unit tests for the bottom navigation component to verify nav items, active state styling, and navigation behavior.